### PR TITLE
Functools partial and dependency injection examples

### DIFF
--- a/9_4_currying_with_functools_and_class.py
+++ b/9_4_currying_with_functools_and_class.py
@@ -1,0 +1,29 @@
+from functools import partial
+
+
+def add(x, y):
+    return x + y
+
+
+class Add:
+    def __init__(self, x):
+        self.x = x
+
+    def __call__(self, y):
+        return self.x + y
+
+
+def main():
+    add_five = partial(add, 5)
+    result = add_five(10)
+    print(f"Result: {result}")
+
+    add_ten = Add(10)
+    result = add_ten(10)
+    print(f"Result: {result}")
+
+    print(Add(10)(20))
+
+
+if __name__ == "__main__":
+    main()

--- a/9_5_compose_vs_dependency_injection.py
+++ b/9_5_compose_vs_dependency_injection.py
@@ -1,0 +1,34 @@
+from functools import partial
+
+
+def double(a):
+    return a * 2
+
+
+def add_number(a, b):
+    return a + b
+
+
+def square(a):
+    return a**2
+
+
+class UseCase:
+    def __init__(self, double_func, add_one_func, square_func):
+        self.double_func = double_func
+        self.add_one_func = add_one_func
+        self.square_func = square_func
+
+    def __call__(self, value):
+        res = self.double_func(self.add_one_func(value))
+        return self.square_func(res) + 1
+
+
+if __name__ == "__main__":
+    use_case = UseCase(
+        double_func=double,
+        add_one_func=partial(add_number, b=1),
+        square_func=square,
+    )
+    result = use_case(3)
+    print(f"Result: {result}")


### PR DESCRIPTION
Contains:
- an example of std lib functools partial for currying
- an example of usage of `__call__` for turning a class in callable
- an example of dependency injection as a way to pipeline functions
